### PR TITLE
set ip address field to unknown

### DIFF
--- a/src/metabase/driver/crate.clj
+++ b/src/metabase/driver/crate.clj
@@ -21,7 +21,7 @@
     :long             :BigIntegerField
     :float            :FloatField
     :double           :FloatField
-    :ip               :TextField
+    :ip               :UnknownField
     :timestamp        :DateTimeField
     :geo_shape        :DictionaryField
     :geo_point        :ArrayField


### PR DESCRIPTION
`char_length` scalar function doesn't support ip-address field types
