### PR TITLE
changed psql port of Crate

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -59,11 +59,13 @@ node-6() {
 
 
 install-crate() {
-    sudo add-apt-repository ppa:crate/stable -y
+    sudo add-apt-repository ppa:crate/testing -y
     sudo apt-get update
-    sudo apt-get install -y crate
+    sudo apt-get install -y crate=0.57.1-1~trusty
     # ulimit setting refused Crate service to start on CircleCI container - so comment it
     sudo sed -i '/MAX_LOCKED_MEMORY/s/^/#/' /etc/init/crate.conf
+    echo "psql.port: 5200" | sudo tee -a /etc/crate/crate.yml
+    echo "psql.enabled: true" | sudo tee -a /etc/crate/crate.yml
     sudo service crate restart
 }
 

--- a/src/metabase/driver/crate.clj
+++ b/src/metabase/driver/crate.clj
@@ -43,16 +43,15 @@
 
 (defn- crate-spec
   [{:keys [hosts]
-    :or   {hosts "//localhost:5432/"}
     :as   opts}]
   (merge {:classname   "io.crate.client.jdbc.CrateDriver" ; must be in classpath
           :subprotocol "crate"
-          :subname     (str hosts)}
+          :subname     (str "//" hosts "/")}
          (dissoc opts :hosts)))
 
 (defn- can-connect? [details]
   (let [connection-spec (crate-spec details)]
-    (= 1 (first (vals (first (jdbc/query connection-spec ["select 1 from sys.cluster"])))))))
+    (= 1 (first (vals (first (jdbc/query connection-spec ["select 1"])))))))
 
 (defn- string-length-fn [field-key]
   (hsql/call :char_length field-key))
@@ -69,7 +68,7 @@
           :date-interval  crate-util/date-interval
           :details-fields (constantly [{:name         "hosts"
                                         :display-name "Hosts"
-                                        :default      "//localhost:5432/"}])
+                                        :default      "localhost:5432"}])
           :features       (comp (u/rpartial set/difference #{:foreign-keys}) sql/features)})
   sql/ISQLDriver
   (merge (sql/ISQLDriverDefaultsMixin)

--- a/test/metabase/test/data/crate.clj
+++ b/test/metabase/test/data/crate.clj
@@ -51,8 +51,7 @@
       (insert! rows))))
 
 (def ^:private database->connection-details
-  (constantly {:host "localhost"
-               :port 4300}))
+  (constantly {:hosts "localhost:5200"}))
 
 (extend CrateDriver
   generic/IGenericSQLDatasetLoader


### PR DESCRIPTION
to avoid test conflicts with the standard PostgreSQL port 5432
the default port of CrateDB is now set to 5200.